### PR TITLE
missing css file referenced

### DIFF
--- a/django_slick_admin/templates/admin/base_site.html
+++ b/django_slick_admin/templates/admin/base_site.html
@@ -6,7 +6,6 @@
 {% block slickhead %}
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <link rel="stylesheet" type="text/css" href="{% static 'django_slick_admin/css/django-slick-admin.css' %}"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/hacks.css' %}"/>
 {% endblock %}
 
 {% block branding %}


### PR DESCRIPTION
```{% static 'admin/css/hacks.css' %}``` was used template.  
